### PR TITLE
corrected invalid link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ description: > # this means to ignore newlines until "baseurl:"
   Topics range from coffee to software design and everything in between.
   Have you accepted Haskell into your home and into your heart?
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://http://the-whiteboard.github.io" # the base hostname & protocol for your site
+url: "http://the-whiteboard.github.io" # the base hostname & protocol for your site
 github_username:  the-whiteboard
 # twitter_username: stackprogrammer
 


### PR DESCRIPTION
The double `http://` schema most noticeably lead to problems with the feed. Oops.

By the way, GH Pages has HTTPS support – would we want to switch the links to that?
