### PR TITLE
redesign: include content only once.

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,3 +1,7 @@
-<header class="site-header">
-
+<header class="site-header container">
+  <div class="row">
+    <div class="col-12">
+      <h1><a style="color:#fff" href="/">{{ site.title }}</a></h1>
+    </div>
+  </div>
 </header>

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,11 +1,6 @@
 <div class="sidebar">
   <div class="row">
     <div class="col-12">
-      <h1><a href="/">{{ site.title }}</a></h1>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
       <p>{{ site.description }}</p>
     </div>
   </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html>
   {% include head.html %}
-  <body class="container left">
-    <div class="row none-tablet"> <!-- none-tablet just means display:none; on tablet and larger screens -->
-      <div class="col-12 secondary primary-border-bottom">{% include sidebar.html %}</div>
-      <div class="push-1 col-10">{{ content }}</div>
-    </div>
-    <div class="row none block-tablet secondary"> <!-- block-tablet means display:block; on tablet and
-                                                       larger, none means display:none up to all screen
-                                                       sizes. Block-tablet overrides the none when tablet
-                                                       screen or larger. -->
-      <div class="col-4">{% include sidebar.html %}</div>
-      <div class="col-8 primary secondary-glow primary-border-left" style="min-height: 100vh;">{{ content }}</div>
-    </div>
+  <body class="secondary" style="min-height:100%; width:100%">
+  {% include header.html %}
+    <div class="container">
+      <div class="row row-bottom-15">
+        <div class="col-12
+                    col-4-tablet
+                    right"
+          >{% include sidebar.html %}</div>
+        <div class="col-10        push-1
+                    col-8-tablet  no-push-tablet
+                    primary secondary-glow"
+          >{{ content }}</div>
+      </div>
   </body>
 </html>


### PR DESCRIPTION
Previously, the content was included twice: once for mobile devices,
once for desktops. This prevents link anchors/IDs from working, and is
overall crappy. We now include the content _once_, and switch between
mobile and columnar layout via responsive CSS classes.

However, the existing design cannot be easily reproduced 1:1. For
aesthetic purposes, the site now has a full blue background, is now
centered, has the name at the top before any content, and switches the
sidebar to the right side where it is less obstrusive. The content now
looks more paper-y.

In mobile mode, the site is essentially unchanged:

![2016-09-17-the-whiteboard-redesign-mobile](https://cloud.githubusercontent.com/assets/1782927/18607571/d63b363c-7cd0-11e6-93ed-162c22c4e9d2.png)

In desktop mode, the site is centered, and more blue:

![2016-09-17-the-whiteboard-redesign-post](https://cloud.githubusercontent.com/assets/1782927/18607573/e20b0f64-7cd0-11e6-90c9-9da26eb7efd1.png)

Is this good? Or were you attached prefer the previous layout?
